### PR TITLE
fix: reset PledgeModal state when reopened for a different campaign

### DIFF
--- a/src/components/ui/PledgeModal.tsx
+++ b/src/components/ui/PledgeModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { X, CheckCircle2, AlertCircle, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -19,6 +19,15 @@ export function PledgeModal({ isOpen, onClose, campaignTitle }: PledgeModalProps
   const [pledgeAmount, setPledgeAmount] = useState<string>("100")
   const [txState, setTxState] = useState<TxState>("idle")
   const [errorMessage, setErrorMessage] = useState<string>("")
+
+  // Reset state when modal opens (isOpen transitions from false to true)
+  useEffect(() => {
+    if (isOpen) {
+      setPledgeAmount("100")
+      setTxState("idle")
+      setErrorMessage("")
+    }
+  }, [isOpen])
 
   const handlePledge = async () => {
     if (!address) {


### PR DESCRIPTION
## Summary

When a user opens the PledgeModal for one campaign, types an amount or encounters an error, closes it, then opens it for a different campaign, the previous `pledgeAmount` and `txState` are still set. The modal now always opens in a clean idle state.

## Changes

- Added `useEffect` watching `isOpen` that resets `pledgeAmount` to "100", `txState` to "idle", and clears `errorMessage` whenever the modal opens
- Imported `useEffect` from React

## Acceptance Criteria

- pledgeAmount resets to "100" and txState resets to "idle" every time the modal opens
- Error message is cleared on reopen
- Works across opening the same campaign twice or two different campaigns in sequence

Closes #2
