### PR TITLE
feat: Implement Claim Refund flow for failed campaigns

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { ProgressBar } from "@/components/ui/ProgressBar"
 import { CountdownTimer } from "@/components/ui/CountdownTimer"
 import { Button } from "@/components/ui/button"
 import { PledgeModal } from "@/components/ui/PledgeModal"
+import { RefundModal } from "@/components/ui/RefundModal"
 import { getCampaigns, type Campaign } from "@/lib/soroban"
 
 function CampaignSkeleton() {
@@ -34,6 +35,7 @@ export default function Home() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedCampaign, setSelectedCampaign] = useState<string | null>(null)
+  const [selectedRefundCampaign, setSelectedRefundCampaign] = useState<Campaign | null>(null)
 
   useEffect(() => {
     async function fetchCampaigns() {
@@ -62,6 +64,10 @@ export default function Home() {
 
   const closePledgeModal = () => {
     setSelectedCampaign(null)
+  }
+
+  const closeRefundModal = () => {
+    setSelectedRefundCampaign(null)
   }
 
   return (
@@ -122,22 +128,29 @@ export default function Home() {
             {campaigns.map((campaign) => {
               const progress = (campaign.raised / campaign.goal) * 100
               const isFunded = progress >= 100
+              const isFailed =
+                !isFunded && new Date(campaign.deadline) < new Date()
 
               return (
-                <div 
+                <div
                   key={campaign.id}
                   className="group flex flex-col bg-card border border-card-border rounded-2xl overflow-hidden hover:shadow-2xl hover:shadow-primary/10 transition-all duration-300 transform hover:-translate-y-1"
                 >
                   <div className="relative h-48 overflow-hidden">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img 
-                      src={campaign.image} 
-                      alt={campaign.title} 
+                    <img
+                      src={campaign.image}
+                      alt={campaign.title}
                       className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
                     />
                     <div className="absolute top-3 right-3">
                       <CountdownTimer deadline={campaign.deadline} />
                     </div>
+                    {isFailed && (
+                      <div className="absolute top-3 left-3 bg-red-500/90 text-white text-xs font-semibold px-2 py-1 rounded-lg">
+                        Failed
+                      </div>
+                    )}
                   </div>
 
                   <div className="p-6 flex-1 flex flex-col">
@@ -155,14 +168,24 @@ export default function Home() {
                         <ProgressBar progress={progress} />
                       </div>
 
-                      <Button 
-                        className="w-full font-bold" 
-                        variant={isFunded ? "secondary" : "default"}
-                        onClick={() => !isFunded && handlePledgeClick(campaign.title)}
-                        disabled={isFunded}
-                      >
-                        {isFunded ? "Successfully Funded" : "Pledge Now"}
-                      </Button>
+                      {isFailed ? (
+                        <Button
+                          className="w-full font-bold"
+                          variant="destructive"
+                          onClick={() => setSelectedRefundCampaign(campaign)}
+                        >
+                          Claim Refund
+                        </Button>
+                      ) : (
+                        <Button
+                          className="w-full font-bold"
+                          variant={isFunded ? "secondary" : "default"}
+                          onClick={() => !isFunded && handlePledgeClick(campaign.title)}
+                          disabled={isFunded}
+                        >
+                          {isFunded ? "Successfully Funded" : "Pledge Now"}
+                        </Button>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -172,10 +195,16 @@ export default function Home() {
         )}
       </main>
 
-      <PledgeModal 
-        isOpen={!!selectedCampaign} 
-        onClose={closePledgeModal} 
-        campaignTitle={selectedCampaign || ""} 
+      <PledgeModal
+        isOpen={!!selectedCampaign}
+        onClose={closePledgeModal}
+        campaignTitle={selectedCampaign || ""}
+      />
+
+      <RefundModal
+        isOpen={!!selectedRefundCampaign}
+        onClose={closeRefundModal}
+        campaignTitle={selectedRefundCampaign?.title || ""}
       />
     </div>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,9 @@ export default function Home() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedCampaign, setSelectedCampaign] = useState<string | null>(null)
+  const [pledgeModalKey, setPledgeModalKey] = useState(0)
   const [selectedRefundCampaign, setSelectedRefundCampaign] = useState<Campaign | null>(null)
+  const [refundModalKey, setRefundModalKey] = useState(0)
 
   useEffect(() => {
     async function fetchCampaigns() {
@@ -60,6 +62,7 @@ export default function Home() {
 
   const handlePledgeClick = (title: string) => {
     setSelectedCampaign(title)
+    setPledgeModalKey((k) => k + 1)
   }
 
   const closePledgeModal = () => {
@@ -172,7 +175,7 @@ export default function Home() {
                         <Button
                           className="w-full font-bold"
                           variant="destructive"
-                          onClick={() => setSelectedRefundCampaign(campaign)}
+                          onClick={() => { setSelectedRefundCampaign(campaign); setRefundModalKey((k) => k + 1) }}
                         >
                           Claim Refund
                         </Button>
@@ -196,12 +199,14 @@ export default function Home() {
       </main>
 
       <PledgeModal
+        key={pledgeModalKey}
         isOpen={!!selectedCampaign}
         onClose={closePledgeModal}
         campaignTitle={selectedCampaign || ""}
       />
 
       <RefundModal
+        key={refundModalKey}
         isOpen={!!selectedRefundCampaign}
         onClose={closeRefundModal}
         campaignTitle={selectedRefundCampaign?.title || ""}

--- a/src/components/ui/PledgeModal.tsx
+++ b/src/components/ui/PledgeModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect } from "react"
+import React, { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { X, CheckCircle2, AlertCircle, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -19,15 +19,6 @@ export function PledgeModal({ isOpen, onClose, campaignTitle }: PledgeModalProps
   const [pledgeAmount, setPledgeAmount] = useState<string>("100")
   const [txState, setTxState] = useState<TxState>("idle")
   const [errorMessage, setErrorMessage] = useState<string>("")
-
-  // Reset state when modal opens (isOpen transitions from false to true)
-  useEffect(() => {
-    if (isOpen) {
-      setPledgeAmount("100")
-      setTxState("idle")
-      setErrorMessage("")
-    }
-  }, [isOpen])
 
   const handlePledge = async () => {
     if (!address) {

--- a/src/components/ui/RefundModal.tsx
+++ b/src/components/ui/RefundModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect } from "react"
+import React, { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { X, CheckCircle2, AlertCircle, Loader2, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -24,13 +24,6 @@ export function RefundModal({
   const { address, connect } = useWallet()
   const [txState, setTxState] = useState<TxState>("idle")
   const [errorMessage, setErrorMessage] = useState<string>("")
-
-  useEffect(() => {
-    if (isOpen) {
-      setTxState("idle")
-      setErrorMessage("")
-    }
-  }, [isOpen])
 
   const handleClaimRefund = async () => {
     if (!address) {

--- a/src/components/ui/RefundModal.tsx
+++ b/src/components/ui/RefundModal.tsx
@@ -1,0 +1,206 @@
+"use client"
+
+import React, { useState, useEffect } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { X, CheckCircle2, AlertCircle, Loader2, RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useWallet } from "@/context/WalletContext"
+
+interface RefundModalProps {
+  isOpen: boolean
+  onClose: () => void
+  campaignTitle: string
+  pledgedAmount?: number
+}
+
+type TxState = "idle" | "processing" | "success" | "error"
+
+export function RefundModal({
+  isOpen,
+  onClose,
+  campaignTitle,
+  pledgedAmount,
+}: RefundModalProps) {
+  const { address, connect } = useWallet()
+  const [txState, setTxState] = useState<TxState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string>("")
+
+  useEffect(() => {
+    if (isOpen) {
+      setTxState("idle")
+      setErrorMessage("")
+    }
+  }, [isOpen])
+
+  const handleClaimRefund = async () => {
+    if (!address) {
+      await connect()
+      return
+    }
+
+    setTxState("processing")
+
+    try {
+      // Simulate Freighter transaction signing for refund
+      await new Promise((resolve) => setTimeout(resolve, 2500))
+
+      setTxState("success")
+
+      setTimeout(() => {
+        setTxState("idle")
+        onClose()
+      }, 3000)
+    } catch (err) {
+      setTxState("error")
+      const message = err instanceof Error ? err.message : String(err)
+      setErrorMessage(message || "Refund transaction failed or was rejected.")
+    }
+  }
+
+  const handleClose = () => {
+    if (txState === "processing") return
+    setTxState("idle")
+    onClose()
+  }
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <React.Fragment>
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={handleClose}
+            className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm"
+          />
+
+          {/* Modal content */}
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 20 }}
+              className="w-full max-w-md bg-card border border-card-border rounded-2xl shadow-2xl p-6 pointer-events-auto"
+            >
+              <div className="flex justify-between items-center mb-6">
+                <h2 className="text-xl font-bold text-foreground">Claim Refund</h2>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleClose}
+                  disabled={txState === "processing"}
+                  className="rounded-full"
+                  aria-label="Close refund modal"
+                >
+                  <X className="w-5 h-5 text-foreground/60" />
+                </Button>
+              </div>
+
+              {txState === "success" ? (
+                <div className="flex flex-col items-center py-8 text-center">
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    transition={{ type: "spring", bounce: 0.5 }}
+                    className="w-16 h-16 bg-green-500/20 text-green-500 rounded-full flex items-center justify-center mb-4"
+                  >
+                    <CheckCircle2 className="w-8 h-8" />
+                  </motion.div>
+                  <h3 className="text-2xl font-bold mb-2">Refund Successful!</h3>
+                  <p className="text-foreground/70">
+                    Your pledge to{" "}
+                    <span className="font-semibold text-foreground">{campaignTitle}</span>{" "}
+                    has been refunded to your wallet.
+                  </p>
+                </div>
+              ) : txState === "error" ? (
+                <div className="flex flex-col items-center py-8 text-center">
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    className="w-16 h-16 bg-red-500/20 text-red-500 rounded-full flex items-center justify-center mb-4"
+                  >
+                    <AlertCircle className="w-8 h-8" />
+                  </motion.div>
+                  <h3 className="text-2xl font-bold mb-2">Refund Failed</h3>
+                  <p className="text-foreground/70 mb-6">{errorMessage}</p>
+                  <Button
+                    variant="outline"
+                    onClick={() => setTxState("idle")}
+                    className="w-full"
+                  >
+                    Try Again
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  {/* Campaign failed notice */}
+                  <div className="flex items-start gap-3 bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3">
+                    <AlertCircle className="w-5 h-5 text-red-400 mt-0.5 shrink-0" />
+                    <p className="text-sm text-red-300">
+                      This campaign did not reach its funding goal and has expired. You are
+                      eligible to claim a full refund.
+                    </p>
+                  </div>
+
+                  <div className="bg-background/50 border border-card-border rounded-xl px-4 py-3 space-y-2">
+                    <div className="flex justify-between text-sm">
+                      <span className="text-foreground/60">Campaign</span>
+                      <span className="font-semibold text-foreground text-right line-clamp-1 max-w-[60%]">
+                        {campaignTitle}
+                      </span>
+                    </div>
+                    {pledgedAmount !== undefined && pledgedAmount > 0 && (
+                      <div className="flex justify-between text-sm">
+                        <span className="text-foreground/60">Refund amount</span>
+                        <span className="font-semibold text-primary">
+                          {pledgedAmount.toLocaleString()} XLM
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  <p className="text-sm text-foreground/60">
+                    Proceeding will initiate a refund transaction via your connected wallet.
+                    The XLM will be returned to{" "}
+                    {address ? (
+                      <span className="font-mono text-foreground/80">
+                        {address.substring(0, 5)}...{address.substring(address.length - 4)}
+                      </span>
+                    ) : (
+                      "your wallet"
+                    )}
+                    .
+                  </p>
+
+                  <Button
+                    onClick={handleClaimRefund}
+                    disabled={txState === "processing"}
+                    variant="destructive"
+                    className="w-full h-12 text-lg mt-2"
+                  >
+                    {txState === "processing" ? (
+                      <span className="flex items-center gap-2">
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                        Processing Refund…
+                      </span>
+                    ) : !address ? (
+                      "Connect Wallet to Claim"
+                    ) : (
+                      <span className="flex items-center gap-2">
+                        <RotateCcw className="w-5 h-5" />
+                        Claim Refund
+                      </span>
+                    )}
+                  </Button>
+                </div>
+              )}
+            </motion.div>
+          </div>
+        </React.Fragment>
+      )}
+    </AnimatePresence>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `RefundModal` component (`src/components/ui/RefundModal.tsx`) with idle/processing/success/error states — mirrors the `PledgeModal` pattern
- Detect failed campaigns: `new Date(campaign.deadline) < new Date() && campaign.raised < campaign.goal`
- Show a red **"Failed"** badge overlay on the campaign card image for expired/failed campaigns
- Replace the **"Pledge Now"** button with a **"Claim Refund"** (destructive variant) button for failed campaigns
- `RefundModal` displays:
  - A campaign-failed alert notice explaining eligibility
  - Campaign name and refund amount summary
  - The destination wallet address for the refund
  - Processing, success, and error states with animated feedback
- Simulates refund transaction signing via Freighter (same 2.5 s delay pattern as `PledgeModal`)
- Auto-closes and resets state 3 s after a successful refund

Closes #4

## Test plan

- [ ] Verify failed campaigns (deadline past, goal unmet) show the "Failed" badge and "Claim Refund" button
- [ ] Verify active campaigns still show "Pledge Now" / "Successfully Funded"
- [ ] Verify RefundModal opens on "Claim Refund" click and shows correct campaign name
- [ ] Verify processing state shows spinner and disables close
- [ ] Verify success state animates and modal auto-closes after 3 s
- [ ] Verify error state shows "Try Again" button
- [ ] Verify wallet connect prompt shows when no wallet connected
