### PR TITLE
feat: add live grace-period countdown to withdrawal flow

### DIFF
--- a/FEATURE_FLAGS.md
+++ b/FEATURE_FLAGS.md
@@ -68,6 +68,9 @@ Best for: gradual rollouts, A/B testing, canary releases.
 |                     |                     |                              | `simulateTransaction` flow to the new indexer endpoint.      |                                                |
 | `admin-console`     | `boolean`           | `enabled: true`              | Admin moderation console at `/admin` (Issue 70).             | Replaced by backend auth system                |
 |                     |                     |                              | Requires `NEXT_PUBLIC_ADMIN_SECRET` env var.                 |                                                |
+| `grace-period-countdown-mock` | `boolean` | `enabled: false`             | Injects a deterministic mock `fundedAt` for funded campaigns | Contract returns a real fundedAt               |
+|                     |                     |                              | so the withdrawal grace-period countdown (Issue 34) can be   |                                                |
+|                     |                     |                              | built/reviewed. Dev/review aid only.                         |                                                |
 
 ---
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -65,5 +65,12 @@
     "hours": "{count}س",
     "minutes": "{count}د",
     "aria_label": "الوقت المتبقي: {days} أيام، {hours} ساعات، {minutes} دقائق"
+  },
+  "GracePeriodCountdown": {
+    "days": "{count}ي",
+    "hours": "{count}س",
+    "minutes": "{count}د",
+    "opens_in": "يفتح السحب خلال {days} {hours} {minutes}",
+    "aria_label": "يفتح السحب خلال {days} أيام، {hours} ساعات، {minutes} دقائق"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -65,5 +65,12 @@
     "hours": "{count}h",
     "minutes": "{count}m",
     "aria_label": "Time remaining: {days} days, {hours} hours, {minutes} minutes"
+  },
+  "GracePeriodCountdown": {
+    "days": "{count}d",
+    "hours": "{count}h",
+    "minutes": "{count}m",
+    "opens_in": "Opens in {days} {hours} {minutes}",
+    "aria_label": "Withdrawal opens in {days} days, {hours} hours, {minutes} minutes"
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -6,6 +6,7 @@ import { useTranslations, useLocale } from "next-intl"
 import { Navbar } from "@/components/layout/Navbar"
 import { ProgressBar } from "@/components/ui/ProgressBar"
 import { CountdownTimer } from "@/components/ui/CountdownTimer"
+import { GracePeriodCountdown } from "@/components/ui/GracePeriodCountdown"
 import { Button } from "@/components/ui/button"
 import { PledgeModal } from "@/components/ui/PledgeModal"
 import { RefundModal } from "@/components/ui/RefundModal"
@@ -17,8 +18,7 @@ import { useFeatureFlag } from "@/hooks/useFeatureFlag"
 import {
   getRemainingBalance,
   getWithdrawalState,
-  isWithinGracePeriod,
-  getGracePeriodEndsAt,
+  withMockFundedAt,
 } from "@/lib/withdrawal"
 import { formatXlm } from "@/lib/format"
 import { ChevronDown, ChevronUp } from "lucide-react"
@@ -153,8 +153,7 @@ export default function Home() {
     const isOwner = campaign.owner ? address === campaign.owner : !!address
     const remainingBalance = getRemainingBalance(campaign)
     const withdrawalState = getWithdrawalState(campaign)
-    const gracePeriodActive = isWithinGracePeriod(campaign)
-    const graceEndsAt = getGracePeriodEndsAt(campaign)
+    const effectiveCampaign = withMockFundedAt(campaign, address)
 
     return (
       <div className="group flex flex-col bg-card border border-card-border rounded-2xl overflow-hidden hover:shadow-2xl hover:shadow-primary/10 transition-all duration-300 transform hover:-translate-y-1">
@@ -230,21 +229,20 @@ export default function Home() {
                 </div>
 
                 {isOwner ? (
-                  <Button
-                    className="w-full font-bold"
-                    variant={withdrawalState === "full" ? "secondary" : "default"}
-                    disabled={withdrawalState === "full" || gracePeriodActive || remainingBalance <= 0}
-                    onClick={() => {
-                      setSelectedWithdrawCampaign(campaign)
-                      setWithdrawModalKey((k) => k + 1)
-                    }}
-                  >
-                    {withdrawalState === "full"
-                      ? "Fully Withdrawn"
-                      : gracePeriodActive
-                      ? `Withdrawal opens ${graceEndsAt ? new Date(graceEndsAt).toLocaleString() : "soon"}`
-                      : "Withdraw Funds"}
-                  </Button>
+                  withdrawalState === "full" ? (
+                    <Button className="w-full font-bold" variant="secondary" disabled>
+                      Fully Withdrawn
+                    </Button>
+                  ) : (
+                    <GracePeriodCountdown
+                      campaign={effectiveCampaign}
+                      remainingBalance={remainingBalance}
+                      onWithdraw={() => {
+                        setSelectedWithdrawCampaign(campaign)
+                        setWithdrawModalKey((k) => k + 1)
+                      }}
+                    />
+                  )
                 ) : (
                   <Button className="w-full font-bold" variant="secondary" disabled>
                     {t("successfully_funded")}

--- a/src/components/ui/GracePeriodCountdown.tsx
+++ b/src/components/ui/GracePeriodCountdown.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import React from "react"
+import { Clock } from "lucide-react"
+import { useTranslations, useLocale } from "next-intl"
+import { Button } from "@/components/ui/button"
+import type { Campaign } from "@/lib/soroban"
+import { useGracePeriodStatus } from "@/hooks/useGracePeriodStatus"
+import { formatCountdownParts } from "@/lib/format"
+
+interface GracePeriodCountdownProps {
+  campaign: Campaign
+  remainingBalance: number
+  onWithdraw: () => void
+}
+
+export function GracePeriodCountdown({
+  campaign,
+  remainingBalance,
+  onWithdraw,
+}: GracePeriodCountdownProps) {
+  const t = useTranslations("GracePeriodCountdown")
+  const locale = useLocale()
+  const { active, msRemaining } = useGracePeriodStatus(campaign.fundedAt)
+
+  if (active) {
+    const { days, hours, minutes } = formatCountdownParts(msRemaining, locale)
+    return (
+      <Button
+        className="w-full font-bold"
+        variant="default"
+        disabled
+        aria-label={t("aria_label", { days, hours, minutes })}
+      >
+        <Clock className="w-4 h-4 shrink-0" aria-hidden="true" />
+        <span dir="ltr" className="tabular-nums ms-1.5" aria-hidden="true">
+          {t("opens_in", {
+            days: t("days", { count: days }),
+            hours: t("hours", { count: hours }),
+            minutes: t("minutes", { count: minutes }),
+          })}
+        </span>
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      className="w-full font-bold"
+      variant="default"
+      disabled={remainingBalance <= 0}
+      onClick={onWithdraw}
+    >
+      Withdraw Funds
+    </Button>
+  )
+}

--- a/src/hooks/useGracePeriodStatus.ts
+++ b/src/hooks/useGracePeriodStatus.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { isWithinGracePeriod, getGracePeriodEndsAt } from "@/lib/withdrawal"
+
+export interface GracePeriodStatus {
+  active: boolean
+  endsAt: string | null
+  msRemaining: number
+}
+
+const TICK_MS = 1000
+
+function computeGracePeriodStatus(fundedAt: string | undefined): GracePeriodStatus {
+  const campaign = { fundedAt }
+  const endsAt = getGracePeriodEndsAt(campaign)
+  const active = isWithinGracePeriod(campaign)
+  const msRemaining = endsAt ? Math.max(0, new Date(endsAt).getTime() - Date.now()) : 0
+  return { active, endsAt, msRemaining }
+}
+
+/**
+ * Live-ticking grace-period status, re-derived every second directly from
+ * lib/withdrawal.ts so the withdraw-gating UI reflects the active -> elapsed
+ * transition without a page refresh (Issue 34).
+ *
+ * @param fundedAt - ISO timestamp of when the campaign was funded, or
+ *                   undefined when the contract hasn't reported one yet.
+ */
+export function useGracePeriodStatus(fundedAt: string | undefined): GracePeriodStatus {
+  const [status, setStatus] = useState<GracePeriodStatus>(() =>
+    computeGracePeriodStatus(fundedAt)
+  )
+
+  useEffect(() => {
+    const tick = () => setStatus(computeGracePeriodStatus(fundedAt))
+
+    tick()
+    const timer = setInterval(tick, TICK_MS)
+    return () => clearInterval(timer)
+  }, [fundedAt])
+
+  return status
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -75,6 +75,17 @@ const FLAG_REGISTRY: Record<string, FlagDefinition> = {
     type: "boolean",
     enabled: true,
   },
+
+  // ---- Issue 34: Grace Period Countdown ----
+  // Injects a deterministic mock `fundedAt` for funded campaigns that don't
+  // yet have a contract-tracked one, so the withdrawal grace-period
+  // countdown UI can be built and reviewed before the contract returns a
+  // real fundedAt. Dev/review aid only — must stay off wherever real
+  // contract data is read.
+  "grace-period-countdown-mock": {
+    type: "boolean",
+    enabled: false,
+  },
 } as const
 
 // ---------------------------------------------------------------------------

--- a/src/lib/withdrawal.ts
+++ b/src/lib/withdrawal.ts
@@ -1,4 +1,5 @@
 import type { Campaign } from "@/lib/soroban"
+import { isFlagEnabled } from "@/lib/feature-flags"
 
 export type WithdrawalState = "none" | "partial" | "full"
 
@@ -50,14 +51,47 @@ export function getMaxSingleWithdrawal(campaign: Campaign): number {
  * period even applies, so we conservatively treat it as already elapsed
  * (Issue 34 should supply a real timestamp and dispute status here).
  */
-export function isWithinGracePeriod(campaign: Campaign): boolean {
+export function isWithinGracePeriod(campaign: Pick<Campaign, "fundedAt">): boolean {
   if (!campaign.fundedAt) return false
   const fundedAtMs = new Date(campaign.fundedAt).getTime()
   return Date.now() - fundedAtMs < GRACE_PERIOD_MS
 }
 
-export function getGracePeriodEndsAt(campaign: Campaign): string | null {
+export function getGracePeriodEndsAt(campaign: Pick<Campaign, "fundedAt">): string | null {
   if (!campaign.fundedAt) return null
   const fundedAtMs = new Date(campaign.fundedAt).getTime()
   return new Date(fundedAtMs + GRACE_PERIOD_MS).toISOString()
+}
+
+/** Feature flag gating the mocked `fundedAt` injected by withMockFundedAt below. */
+export const GRACE_PERIOD_MOCK_FLAG = "grace-period-countdown-mock"
+
+const MOCK_GRACE_SESSION_START_MS = Date.now()
+
+/**
+ * Deterministic hash of a string into [0, rangeMs). Used to spread mocked
+ * fundedAt offsets across the grace window by campaign id, so some cards
+ * render active and others elapsed instead of all landing on the same state.
+ */
+function hashOffsetMs(seed: string, rangeMs: number): number {
+  let hash = 0
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) & 0xffffffff
+  }
+  return Math.abs(hash) % rangeMs
+}
+
+/**
+ * Injects a deterministic mock `fundedAt` for funded campaigns that don't
+ * yet have a contract-tracked one, gated behind GRACE_PERIOD_MOCK_FLAG
+ * (Issue 34), so the grace-period UI can be built and reviewed against
+ * realistic data before the contract actually returns fundedAt. No-op
+ * when the flag is off or a real fundedAt is already present.
+ */
+export function withMockFundedAt(campaign: Campaign, seed?: string | null): Campaign {
+  if (campaign.fundedAt) return campaign
+  if (!isFlagEnabled(GRACE_PERIOD_MOCK_FLAG, seed)) return campaign
+  const offsetMs = hashOffsetMs(campaign.id, GRACE_PERIOD_MS)
+  const fundedAt = new Date(MOCK_GRACE_SESSION_START_MS - offsetMs).toISOString()
+  return { ...campaign, fundedAt }
 }


### PR DESCRIPTION
closes #100 

Description
Build a live countdown component for the post-funding dispute/grace window. lib/withdrawal.ts's isWithinGracePeriod currently returns false unconditionally whenever campaign.fundedAt is unset ("Without a contract-tracked fundedAt, there's no way to know a grace period even applies... conservatively treat it as already elapsed") — meaning the grace-period UI path has never actually been exercised end-to-end. Build it against a typed, feature-flagged fundedAt source so it's ready the moment the contract returns it.

The grace period exists to give backers a window after a campaign is funded to raise a dispute before the owner can withdraw — it's a trust mechanism, not just a UX delay. Because isWithinGracePeriod currently defaults to "elapsed" whenever fundedAt is missing, the withdraw button has effectively always been enabled in every environment that's shipped so far, and nobody has ever seen — or tested — what the app actually does while a real grace period is ticking down. That's a gap worth closing before the contract wires up fundedAt for real, not after: the countdown, the disabled-state styling, the live transition to "elapsed", and the RTL/locale formatting all need to be proven out against realistic data now, rather than discovered for the first time in production once withdrawals are actually gated.